### PR TITLE
Fix problem with LFO stomping on filter envelope

### DIFF
--- a/24-chubgraphs/synthvoice.ck
+++ b/24-chubgraphs/synthvoice.ck
@@ -53,16 +53,6 @@ public class SynthVoice extends Chubgraph
     1 => float osc2Detune;
     0 => int oscOffset;
 
-    fun void processLfo()
-    {        
-        while(true)
-        {
-            filterCutoff + filterLfo.last() => lpf.freq;
-            5::ms => now;
-        }
-    }
-    spork ~ processLfo();
-
     fun void SetOsc1Freq(float frequency)
     {
         frequency => tri1.freq => sqr1.freq => saw1.freq;
@@ -184,14 +174,12 @@ public class SynthVoice extends Chubgraph
 
     fun void filterEnvelope()
     {           
-        filterCutoff => float startFreq;        
-        10::ms => now;     
+        filterCutoff => float startFreq;                
         while((adsr.state() != 0 && adsr.value() == 0) == false)
         {
-            (filterEnv * adsr.value()) + startFreq => lpf.freq;            
-            20::ms => now;
+            (filterEnv * adsr.value()) + startFreq + filterLfo.last() => lpf.freq;                        
+            10::ms => now;  
         }
-
     }
 
     fun void cutoff(float amount)


### PR DESCRIPTION
When I built synthvoice.ck, the filter envelope worked fine when I made it, and then I implemented an LFO afterward. Unfortunately, I neglected to test whether filter envelopes still worked after the LFO was in place. 

The way I implemented the LFO caused the LFO to always "win" over the filter envelope, which was stopping the envelope from working properly. 

This change fixes that situation, and simplifies things as a happy side effect.